### PR TITLE
Fixed issue with duplicate assignment of ref

### DIFF
--- a/front/pagemaker/src/classes/componentCounter/componentCounter.ts
+++ b/front/pagemaker/src/classes/componentCounter/componentCounter.ts
@@ -13,8 +13,6 @@ class ComponentCounter {
     return this.counter;
   }
   public setCounter(counter: number) {
-    console.log('%c⧭', 'color: #735656', counter);
-    console.log('%c⧭', 'color: #cc0088', 'setCounter');
     this.counter = counter;
   }
 

--- a/front/pagemaker/src/classes/componentCounter/componentCounter.ts
+++ b/front/pagemaker/src/classes/componentCounter/componentCounter.ts
@@ -12,12 +12,18 @@ class ComponentCounter {
   public getCounter(): number {
     return this.counter;
   }
+  public setCounter(counter: number) {
+    console.log('%c⧭', 'color: #735656', counter);
+    console.log('%c⧭', 'color: #cc0088', 'setCounter');
+    this.counter = counter;
+  }
+
 
   public getNextCounter(): number {
     const currentCounter: number = this.counter;
     this.counter++;
     return currentCounter;
   }
-};
+}
 
 export { ComponentCounter };

--- a/front/pagemaker/src/common/colourUtils.ts
+++ b/front/pagemaker/src/common/colourUtils.ts
@@ -2,7 +2,7 @@ interface RGB {
   r: number,
   g: number,
   b: number,
-};
+}
 
 const splitRgb = (rgbColour: string) => rgbColour.split('(')[1].split(')')[0].split(',');
 
@@ -10,8 +10,8 @@ function rgbToHex(rgbColour: string): string {
   const splitColours = splitRgb(rgbColour);
   if(splitColours.length > 3) splitColours.pop();
   const coloursAsHex = splitColours.map((colour) => {     
-    colour = parseInt(colour).toString(16);
-    return (colour.length === 1) ? `0${colour}` : colour;
+    const colourAsString = parseInt(colour).toString(16);
+    return (colourAsString.length === 1) ? `0${colourAsString}` : colourAsString;
   });
   return `#${coloursAsHex.join('')}`;
 }

--- a/front/pagemaker/src/components/page/page.vue
+++ b/front/pagemaker/src/components/page/page.vue
@@ -55,9 +55,9 @@ export default defineComponent({
 
   components: {
     container: Container,
-    imageElement: imageElement,
-    buttonElement: buttonElement,
-    textElement: textElement,
+    imageElement,
+    buttonElement,
+    textElement,
     Resize,
 },
 

--- a/front/pagemaker/src/components/page/page.vue
+++ b/front/pagemaker/src/components/page/page.vue
@@ -70,6 +70,10 @@ export default defineComponent({
     }
   },
 
+  mounted() {
+      this.pageBuilderService.initPage();
+  },
+
   computed: {
 
     getScaledPageSize(): string {

--- a/front/pagemaker/src/services/pageBuilder/pageBuilder.service.ts
+++ b/front/pagemaker/src/services/pageBuilder/pageBuilder.service.ts
@@ -16,6 +16,12 @@ function PageBuilderService() {
   const pageStore = usePageStore();
   const editorSettingsService = new EditorSettingsService();
 
+  function initPage() {
+    const componentCount = pageStore.page.elements.length;
+    const componentCounter = ComponentCounter.getInstance();
+    componentCounter.setCounter(componentCount);
+  }
+
   function createNewComponent(componentName: string, parentRef: string) {
     const component = getToolbarComponent(componentName);
     if (component) {
@@ -68,7 +74,9 @@ function PageBuilderService() {
     }
   }
 
-  return { createNewComponent, 
+  return { 
+      initPage,
+      createNewComponent, 
       calcPageSize,
       setScaledDimension,
       processButtonCommand,


### PR DESCRIPTION
When a page is loaded the counter for the page
elements was not beind updated. Added page mounted event to update the counter based on the number of elements loaded.